### PR TITLE
Fix RSS feed links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: Bastion-rs blog
 description: >
   Welcome to the official bastion-rs blog!
 baseurl: ""
-url: "https://bastion-rs"
+url: "https://blog.bastion.rs"
 logo: "https://raw.githubusercontent.com/bastion-rs/bastion-rs.github.io/master/src/assets/images/bastion-logo.png"
 twitter_username: bastion_rs
 github_username: bastion-rs


### PR DESCRIPTION
The post urls in the RSS feed are broken due to this configuration setting (note the link elements):

```xml
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
  <channel>
    <title>Bastion-rs blog</title>
    <description>Welcome to the official bastion-rs blog!</description>
    <link>https://bastion-rs/</link>
    <atom:link href="https://bastion-rs/feed.xml" rel="self" type="application/rss+xml" />
    <pubDate>Sun, 23 Feb 2020 20:45:57 +0000</pubDate>
    <lastBuildDate>Sun, 23 Feb 2020 20:45:57 +0000</lastBuildDate>
    <generator>Jekyll v3.8.5</generator>
      <item>
        <title>Bastion floating on Tide - Part 1</title>
        <description>…</description>
        <pubDate>Sun, 23 Feb 2020 00:00:00 +0000</pubDate>
        <link>https://bastion-rs/2020/02/23/bastion-floating-on-tide-part-1.html</link>
        <guid isPermaLink="true">https://bastion-rs/2020/02/23/bastion-floating-on-tide-part-1.html</guid>
      </item>
```